### PR TITLE
Fixing potential confusion in the server routing

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -85,7 +85,7 @@ class App extends Component {
   handleRegister = e => {
     e.preventDefault();
     axios
-      .post("/user", {
+      .post("/api/user", {
         username: this.state.registerUsername,
         password: this.state.registerPassword
       })
@@ -106,7 +106,7 @@ class App extends Component {
   handleLogin = e => {
     e.preventDefault();
     axios
-      .post("/user/login", {
+      .post("/api/user/login", {
         username: this.state.loginUsername,
         password: this.state.loginPassword
       })
@@ -127,7 +127,7 @@ class App extends Component {
 
   handleLogout = () => {
     axios
-      .delete("/user/logout", {
+      .delete("/api/user/logout", {
         headers: {
           "x-auth": Auth.getToken()
         }

--- a/client/src/components/About/AboutUs.jsx
+++ b/client/src/components/About/AboutUs.jsx
@@ -9,7 +9,7 @@ class AboutUs extends Component {
     dataLoaded:false
   }
   componentDidMount() {
-    axios.get(`/page/${this.state.pageTitle}`).then(res => {
+    axios.get(`/api/page/${this.state.pageTitle}`).then(res => {
       let { pageContent } = res.data;
       console.log(pageContent);
       this.setState({

--- a/client/src/components/About/Careers.jsx
+++ b/client/src/components/About/Careers.jsx
@@ -12,8 +12,8 @@ class Careers extends Component {
 
   componentDidMount() {
     axios.all([
-      axios.get(`/page/${this.state.pageTitle}`),
-      axios.get('/careers')
+      axios.get(`/api/page/${this.state.pageTitle}`),
+      axios.get('/api/careers')
     ]).then(axios.spread((pageRes, careersRes) => {
       let cities =[],
         parseCareers = careersRes.data.jobs.map((job)=>{

--- a/client/src/components/About/OurTeam.jsx
+++ b/client/src/components/About/OurTeam.jsx
@@ -9,7 +9,7 @@ class OurTeam extends Component {
   }
 
   componentDidMount() {
-    axios.get(`/page/${this.state.pageTitle}`).then(res => {
+    axios.get(`/api/page/${this.state.pageTitle}`).then(res => {
       let { pageContent } = res.data;
       console.log(pageContent);
       this.setState({

--- a/client/src/components/About/PeopleSay.jsx
+++ b/client/src/components/About/PeopleSay.jsx
@@ -12,8 +12,8 @@ class PeopleSay extends Component{
 
   componentDidMount() {
       axios.all([
-        axios.get(`/page/${this.state.pageTitle}`),
-        axios.get('/reviews')
+        axios.get(`/api/page/${this.state.pageTitle}`),
+        axios.get('/api/reviews')
       ])
       .then(axios.spread((pageRes, revRes) => {
           this.setState({

--- a/client/src/components/About/Supporters.jsx
+++ b/client/src/components/About/Supporters.jsx
@@ -10,7 +10,7 @@ class Supporters extends Component{
   }
 
   componentDidMount() {
-    axios.get(`/page/${this.state.pageTitle}`).then(res => {
+    axios.get(`/api/page/${this.state.pageTitle}`).then(res => {
       let { pageContent } = res.data;
       console.log(pageContent);
       this.setState({

--- a/client/src/components/AfterSchool/AfterSchoolLocation.jsx
+++ b/client/src/components/AfterSchool/AfterSchoolLocation.jsx
@@ -10,7 +10,7 @@ class AfterSchoolLocations extends Component {
   }
 
   componentDidMount() {
-    axios.get(`/page/${this.state.pageTitle}`).then(res => {
+    axios.get(`/api/page/${this.state.pageTitle}`).then(res => {
       let { pageContent } = res.data;
       console.log(pageContent);
       this.setState({

--- a/client/src/components/AfterSchool/Overview.jsx
+++ b/client/src/components/AfterSchool/Overview.jsx
@@ -10,7 +10,7 @@ class Overview extends Component {
   }
 
   componentDidMount() {
-    axios.get(`/page/${this.state.pageTitle}`).then(res => {
+    axios.get(`/api/page/${this.state.pageTitle}`).then(res => {
       let { pageContent } = res.data;
       console.log(pageContent);
       this.setState({

--- a/client/src/components/AfterSchool/Transportation.jsx
+++ b/client/src/components/AfterSchool/Transportation.jsx
@@ -10,7 +10,7 @@ class Transportation extends Component {
   }
 
   componentDidMount() {
-    axios.get(`/page/${this.state.pageTitle}`).then(res => {
+    axios.get(`/api/page/${this.state.pageTitle}`).then(res => {
       let { pageContent } = res.data;
       console.log(pageContent);
       this.setState({

--- a/client/src/components/Dashboard/CareersUI.jsx
+++ b/client/src/components/Dashboard/CareersUI.jsx
@@ -11,7 +11,7 @@ class CareersUI extends Component{
         jobLink : ''
     } 
     componentDidMount() {
-        axios.get('/careers').then(res=>{
+        axios.get('/api/careers').then(res=>{
             this.setState({
                 careers: res.data.jobs,
                 dataLoaded: true
@@ -34,7 +34,7 @@ class CareersUI extends Component{
                 'state' : newState
             };
         e.preventDefault();
-        axios.post('/careers',{
+        axios.post('/api/careers',{
             'location': JSON.stringify(concatLocation),
             'title': newTitle,
             jobLink
@@ -50,7 +50,7 @@ class CareersUI extends Component{
         }).catch(err => console.log(err));
     }
     removeJob = (id) => {
-        axios.delete(`/careers/${id}`).then(res => {
+        axios.delete(`/api/careers/${id}`).then(res => {
  
             let { _id } = res.data.job,
             newArr = this.state.careers;

--- a/client/src/components/Dashboard/Dashboard.jsx
+++ b/client/src/components/Dashboard/Dashboard.jsx
@@ -61,7 +61,7 @@ class Dashboard extends Component {
     this.getSchoolCoords();
 
     if (this.state.coordsLoaded) {
-      axios.post('/schools/add', {
+      axios.post('/api/schools/add', {
         'schoolName': this.state.schoolName,
         'st_Addr': this.state.st_Addr,
         'city': this.state.city,
@@ -91,7 +91,7 @@ class Dashboard extends Component {
 
   handleAddClass = e => {
     e.preventDefault();
-    axios.post('/classes', {
+    axios.post('/api/classes', {
       'className': this.state.classname,
       'desc': this.state.desc,
       'price': this.state.price,
@@ -126,7 +126,7 @@ class Dashboard extends Component {
 
   async componentDidMount() {
     console.log(this.props)
-    axios.get('/schools/').then(res => {
+    axios.get('/api/schools/').then(res => {
       this.setState({
         schools : res.data,
         schoolsLoaded: true
@@ -134,7 +134,7 @@ class Dashboard extends Component {
     }).catch(err=>{
       console.log(err);
     });
-    await axios.get('/page/').then(res => {
+    await axios.get('/api/page/').then(res => {
       this.setState({
         pages: res.data.pages
       },()=> {

--- a/client/src/components/Dashboard/EditForm.jsx
+++ b/client/src/components/Dashboard/EditForm.jsx
@@ -13,7 +13,7 @@ class EditForm extends Component{
     }
 
     fetchData = (title)=>{
-        axios.get(`/page/${title}`).then(res =>{
+        axios.get(`/api/page/${title}`).then(res =>{
             let { pageContent } = res.data,
             fields = [];
             for(let heading in pageContent){
@@ -67,7 +67,7 @@ class EditForm extends Component{
             newcontent[`${page.headingName}`]=page.value;
         });
 
-        axios.put(`/page/${_id}`,{
+        axios.put(`/api/page/${_id}`,{
             pageTitle,
             'content':newcontent
         }).then(res => {

--- a/client/src/components/Dashboard/EditSchool.jsx
+++ b/client/src/components/Dashboard/EditSchool.jsx
@@ -72,7 +72,7 @@ class EditSchool extends Component {
   editSchool = e => {
     e.preventDefault();
     axios
-      .put(`/schools/${this.props.match.params.school_id}`, {
+      .put(`/api/schools/${this.props.match.params.school_id}`, {
         schoolName: this.state.schoolName,
         st_Addr: this.state.st_Addr,
         city: this.state.city,
@@ -92,7 +92,7 @@ class EditSchool extends Component {
   }
 
   componentDidMount() {
-    axios.get(`/schools/${this.props.match.params.school_id}`)
+    axios.get(`/api/schools/${this.props.match.params.school_id}`)
       .then(res => {
         console.log(res);
         const school = res.data.school;

--- a/client/src/components/Dashboard/ReviewsUI.jsx
+++ b/client/src/components/Dashboard/ReviewsUI.jsx
@@ -10,7 +10,7 @@ class ReviewsUI extends Component{
         newType: 'SeriousFun',
     } 
     componentDidMount() {
-        axios.get('/reviews').then(res=>{
+        axios.get('/api/reviews').then(res=>{
             this.setState({
                 reviews: res.data.reviews,
                 dataLoaded: true
@@ -30,7 +30,7 @@ class ReviewsUI extends Component{
         let { newQuote, newReviewer, newType} = this.state;
         
         e.preventDefault();
-        axios.post('/reviews', {
+        axios.post('/api/reviews', {
             quote: newQuote,
             reviewer: newReviewer,
             typeOfR : newType
@@ -44,7 +44,7 @@ class ReviewsUI extends Component{
         }).catch(err => console.log(err)); 
     }
     removeReview = (id) => {
-        axios.delete(`/reviews/${id}`).then(res => {
+        axios.delete(`/api/reviews/${id}`).then(res => {
  
             let { _id } = res.data.review,
             newArr = this.state.reviews;

--- a/client/src/components/DetailedSchool.jsx
+++ b/client/src/components/DetailedSchool.jsx
@@ -12,7 +12,7 @@ class DetailedSChool  extends Component {
 
     componentDidMount() {
         let id = this.props.match.params.school_id;
-        axios.get(`/schools/${id}`).then(response => {
+        axios.get(`/api/schools/${id}`).then(response => {
             console.log(response)
             this.setState({
                 data: response.data.school,

--- a/client/src/components/Home.jsx
+++ b/client/src/components/Home.jsx
@@ -16,7 +16,7 @@ class Home extends Component {
 
   componentDidMount(){
     let { pageTitle } = this.state;
-    axios.get(`/page/${pageTitle}`).then(res =>{
+    axios.get(`/api/page/${pageTitle}`).then(res =>{
       console.log(res.data);
         this.setState({
           data: res.data,

--- a/client/src/components/Schools.jsx
+++ b/client/src/components/Schools.jsx
@@ -14,7 +14,7 @@ class Schools extends Component{
     }
   }
   componentDidMount(){
-    axios.get('/schools/').then(schools => {
+    axios.get('/api/schools/').then(schools => {
       this.setState({
         schools : schools.data,
         dataLoaded: true

--- a/server.js
+++ b/server.js
@@ -53,19 +53,19 @@ const userRoutes = require('./api/routes/userRoutes');
 app.use('/user', userRoutes);
 
 const schoolRoutes = require('./api/routes/schoolRoutes');
-app.use('/schools', schoolRoutes);
+app.use('/api/schools', schoolRoutes);
 
 const classesRoutes =  require('./api/routes/classRoutes');
-app.use('/classes', classesRoutes);
+app.use('/api/classes', classesRoutes);
 
 const pageRoutes = require('./api/routes/pageRoutes');
-app.use('/page', pageRoutes);
+app.use('/api/page', pageRoutes);
 
 const jobRoutes = require('./api/routes/jobRoutes');
-app.use('/careers', jobRoutes);
+app.use('/api/careers', jobRoutes);
 
 const reviewRoutes = require('./api/routes/reviewRoutes');
-app.use('/reviews', reviewRoutes);
+app.use('/api/reviews', reviewRoutes);
 
 app.get('*', (req, res) => {
   res.status(404).send('not found!');


### PR DESCRIPTION
We currently had all our routes in the server set as the same name as the front end routes to visit the website. For example we had url.com/reviews worked for bot fetching the server data as well as fetching the client html to display that page. This caused an error in some browsers where going to pages with the same routing name would send the serve json response instead of the intended reviews page. To resolve this issue I add /api/ to all the server routes to differentiate server routes from client routes. Now to hit the reviews routes on the server you have to hit /api/reviews and to hit the client url is just url.com/reviews. 