### PR TITLE
Ash heroku routes fix

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -56,7 +56,7 @@ import Schools from './components/Schools';
 import DetailedSchool from './components/DetailedSchool';
 import EditSchool from './components/Dashboard/EditSchool';
 import Footer from './components/Footer';
-import HamburgerMenu from './components/HamburgerMenu';
+// import HamburgerMenu from './components/HamburgerMenu';
 import Contact from './components/Contact';
 import FAQ from './components/FAQ';
 import RegisterHowTo from './components/RegisterHowTo';
@@ -70,7 +70,6 @@ class App extends Component {
     loginUsername: "",
     loginPassword: "",
     open: false,
-    loginPassword: ""
   };
 
   // use of arrow functions to avoid bindings

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -185,7 +185,7 @@ class App extends Component {
           <Route exact path="/afterschoolcalendar" component={AfterSchoolCalendar} />
           <Route exact path="/campCalendar" component={CampCalendar} />
           <Route exact path="/specialevents" component={SpecialEvents} />
-          <Route exact path="/register" component={RegisterHowTo}/>
+          <Route exact path="/registerhowto" component={RegisterHowTo}/>
           <Route exact path="/contact" component={Contact} />
           <Route exact path="/faq" component={FAQ} />
           <Route exact path="/registerOngoing" component={RegisterOngoing}/>

--- a/client/src/components/Calendar/AfterSchoolCalendar.jsx
+++ b/client/src/components/Calendar/AfterSchoolCalendar.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 
 import FullCalendar from "./FullCalendar";
 

--- a/client/src/components/Calendar/CampCalendar.jsx
+++ b/client/src/components/Calendar/CampCalendar.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 
 import FullCalendar from "./FullCalendar";
 

--- a/client/src/components/Calendar/SpecialEvents.jsx
+++ b/client/src/components/Calendar/SpecialEvents.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 
 const SpecialEvents = props => {
   return (

--- a/client/src/components/Home.jsx
+++ b/client/src/components/Home.jsx
@@ -17,7 +17,6 @@ class Home extends Component {
   componentDidMount(){
     let { pageTitle } = this.state;
     axios.get(`/api/page/${pageTitle}`).then(res =>{
-      console.log(res.data);
         this.setState({
           data: res.data,
           content: res.data.pageContent,
@@ -39,13 +38,13 @@ class Home extends Component {
           infiniteLoop
           dynamicHeight >
           <div>
-            <img  />
+            <img alt='' />
           </div>
           <div>
-            <img  />
+            <img alt='' />
           </div>
           <div>
-            <img  />
+            <img alt='' />
           </div>
         </Carousel>
       </div>

--- a/client/src/components/Nav.jsx
+++ b/client/src/components/Nav.jsx
@@ -125,7 +125,7 @@ const Nav = props => {
 
             <div className="dropdownMenu regis">
               <div className="registrationDrop">
-                <Link to="/register" id="registerDrop" className="dropLinks">
+                <Link to="/registerhowto" id="registerDrop" className="dropLinks">
                   How-To Register
                 </Link>
                 <Link to="/registerOngoing" id="onGoingDrop" className="dropLinks">

--- a/client/static.json
+++ b/client/static.json
@@ -1,0 +1,7 @@
+{
+  "root": "build/",
+  "clean_urls": false,
+  "routes": {
+    "/**": "index.html"
+  }
+}


### PR DESCRIPTION
Fixes in this PR

1.  Fixed the navbar link for "how to register" - admin register doesnt show on this component anynore.

2. Tried to fix the routes: This has not been tested. Please deploy and test

referenced from: https://stackoverflow.com/questions/41772411/react-routing-works-in-local-machine-but-not-heroku

----- Create-react-app is for the most part a Node.Js server which serves client-side React. The public static directory is mapped to the / endpoint, and visiting this endpoint from a browser will download the index.html webpage. This webpage in turn loads the React components. And because React Browser Router is a React component, the routes are loaded dynamically after visiting the / endpoint. In other words, before the index.html webpage is loaded all our React Browser Router routes will result in 404 errors on Heroku. To resolve this issue, a static.json file can be used to map any endpoints with the following pattern /** to the index.html file, which in turn will load React Browser Router and correctly load the react components for that route. ------